### PR TITLE
Pyconnectome dmri preproc

### DIFF
--- a/pyconnectome/scripts/pyconnectome_dmri_preproc
+++ b/pyconnectome/scripts/pyconnectome_dmri_preproc
@@ -34,7 +34,7 @@ try:
     bredala.register("pyconnectome.utils.preproctools",
                      names=["eddy", "fsl_prepare_fieldmap", "epi_reg",
                             "smooth_fieldmap", "pixel_shift_to_fieldmap",
-                            "fieldmap_reflect", "topup"])
+                            "fieldmap_reflect", "topup", "convertwarp"])
     bredala.register("pyconnectome.models.tensor",
                      names=["dtifit"])
     bredala.register("pyconnectome.utils.filetools",
@@ -71,6 +71,7 @@ from pyconnectome.utils.preproctools import smooth_fieldmap
 from pyconnectome.utils.preproctools import pixel_shift_to_fieldmap
 from pyconnectome.utils.preproctools import fieldmap_reflect
 from pyconnectome.utils.preproctools import topup
+from pyconnectome.utils.preproctools import convertwarp
 from pyconnectome.models.tensor import dtifit
 from pyconnectome.utils.filetools import fslreorient2std
 from pyconnectome.utils.filetools import apply_mask
@@ -269,13 +270,9 @@ def get_cmd_line_args():
 
     # Optional argument
     parser.add_argument(
-        "-O", "--topup-b0",
-        type=is_file, metavar="<path>", nargs="+",
-        help="The b0 data acquired in opposite phase enc. direction.")
-    parser.add_argument(
-        "-D", "--topup-b0-dir",
-        metavar="<path>", nargs="+", choices=("i", "i-", "j", "j-"),
-        help="The b0 data enc.directions.")
+        "-O", "--topup-b0", type=is_file, metavar="<path>",
+        help="The concatenated b0 data acquired in opposite phase enc. "
+             "direction.")
     parser.add_argument(
         "-K", "--t1-mask",
         type=is_file, metavar="<path>",
@@ -608,7 +605,7 @@ if not inputs["skip_susceptibility"]:
         dwi_corrected_fileroot = os.path.join(susceptibility_dir, "epi2struct")
         # echo_spacing = inputs["echo_spacing"] / (
         #     1000 * inputs["parallel_acceleration_factor"])
-        corrected_epi_file, warp_file, distortion_map = epi_reg(
+        corrected_epi_file, epi_to_t1_warp_file, pixel_shift_map = epi_reg(
             epi_file=inputs["dwi"],
             structural_file=inputs["t1"],
             brain_structural_file=brain_img,
@@ -620,38 +617,36 @@ if not inputs["skip_susceptibility"]:
             phase_encode_dir=phase_enc_dir,
             wmseg_file=inputs["wm_seg"],
             fsl_sh=inputs["fsl_config"])
-        nodif_to_t1_mat = os.path.join(susceptibility_dir, "epi2struct.mat")
         t1_to_nodif_mat = os.path.join(
             susceptibility_dir, "epi2struct_inv.mat")
-        outputs["corrected_epi_file"] = corrected_epi_file
-        outputs["pixel_shift_map"] = distortion_map
 
-        # Reorganize deformation field volume
-        if not os.path.isfile(distortion_map):
-            raise ValueError("Unavailable warp file: {0}".format(
-                distortion_map))
-        distortion_img = nibabel.load(distortion_map)
-        distortion_img_data = distortion_img.get_data()
-        distortion_img_data.shape += (1,)
-        spacing = distortion_img.header.get_zooms()
-        zero_field = numpy.zeros(distortion_img_data.shape)
-        if phase_enc_dir in ("x", "x-"):
-            deformation_field = numpy.concatenate(
-                (distortion_img_data * spacing[0], zero_field, zero_field),
-                axis=3)
-        elif phase_enc_dir in ("y", "y-"):
-            deformation_field = numpy.concatenate(
-                (zero_field, distortion_img_data * spacing[1], zero_field),
-                axis=3)
-        else:
-            raise ValueError("Incorrect phase encode direction: {0}".format(
-                             phase_enc_dir))
-        deformation_field_img = nibabel.Nifti1Image(
-            deformation_field, distortion_img.affine)
-
+        # Fugue can be used to correct susceptibility by applying directly
+        # the fieldmap in EPI space as follow:
+        # > Create a binary mask of fieldmap in EPI space.
+        # fslmaths epi_reg_fileroot_fieldmaprads2epi \
+        #    -abs \
+        #    -bin \
+        #    epi_reg_fileroot_fieldmaprads2epi_mask
+        # > Apply fielmap
+        # fugue \
+        #   -i epi.nii.gz \
+        #   -u epi_corrected.nii.gz \
+        #   --loadfmap=epi_reg_fileroot_fieldmaprads2epi \
+        #   --mask=epi_reg_fileroot_fieldmaprads2epi_mask \
+        #   --dwell=dwell_time \
+        #   --unwarpdir=phase_enc_dir
+        # Another way, which was tested and lead to the same result is to
+        # compute the susceptibility deformation field from the pixel shift map
+        # outputted by epi_reg and to later apply it to EPI image to correct
+        # for susceptibility.
         deformation_field_file = os.path.join(
             susceptibility_dir, "field.nii.gz")
-        nibabel.save(deformation_field_img, deformation_field_file)
+        convertwarp(
+            ref=inputs["dwi"],
+            out=deformation_field_file.replace(".nii.gz", ""),
+            shiftmap=pixel_shift_map,
+            shiftdir=phase_enc_dir,
+            fsl_sh=inputs["fsl_config"])
         outputs["warp_file"] = deformation_field_file
 
     # FSL topup
@@ -662,8 +657,8 @@ if not inputs["skip_susceptibility"]:
 
         # Topup
         fieldmap_hz_to_diff_file, corrected_b0s, mean_corrected_b0s = topup(
-            b0s=inputs["topup_b0"],
-            phase_enc_dirs=inputs["topup_b0_dir"],
+            concat_b0s=inputs["topup_b0"],
+            acqp_file=inputs["acqp"],
             readout_time=inputs["readout_time"],
             outroot=susceptibility_dir,
             fsl_sh=inputs["fsl_config"])
@@ -679,19 +674,6 @@ if not inputs["skip_susceptibility"]:
                 arr = numpy.delete(arr, -1, axis=cnt)
         im = nibabel.Nifti1Image(arr, im.affine)
         nibabel.save(im, inputs["dwi"])
-
-        # Coregistration only
-        dwi_corrected_fileroot = os.path.join(susceptibility_dir, "epi2struct")
-        corrected_epi_file, _, _ = epi_reg(
-            epi_file=inputs["dwi"],
-            structural_file=inputs["t1"],
-            brain_structural_file=brain_img,
-            output_fileroot=dwi_corrected_fileroot,
-            wmseg_file=None,
-            fsl_sh=inputs["fsl_config"])
-        nodif_to_t1_mat = os.path.join(susceptibility_dir, "epi2struct.mat")
-        t1_to_nodif_mat = os.path.join(
-            susceptibility_dir, "epi2struct_inv.mat")
 
     # Brainsuite
     else:
@@ -712,7 +694,7 @@ if not inputs["skip_susceptibility"]:
             raise ValueError("Incorrect phase encode direction: {0}...".format(
                              inputs["phase-encode-dir"]))
 
-        warp_file = os.path.join(
+        pixel_shift_map = os.path.join(
             susceptibility_dir,
             "{0}.dwi.RAS.correct.distortion.map.nii.gz".format(
                 inputs["subject"]))
@@ -724,7 +706,7 @@ if not inputs["skip_susceptibility"]:
                 inputs["subject"]))
 
         # Start correction
-        if (not os.path.isfile(warp_file) and not
+        if (not os.path.isfile(pixel_shift_map) and not
                 os.path.isfile(dwi_wo_susceptibility) and not
                 os.path.isfile(t1_in_dwi_space)):
             (dwi_wo_susceptibility, bval, bvec, t1_in_dwi_space,
@@ -776,12 +758,13 @@ if not inputs["skip_susceptibility"]:
                 to_rm_file = os.path.join(
                     susceptibility_dir, basename.format(inputs["subject"]))
                 os.remove(to_rm_file)
-        outputs["pixel_shift_map"] = warp_file
+        outputs["pixel_shift_map"] = pixel_shift_map
 
         # Reorganize deformation field volume
-        if not os.path.isfile(warp_file):
-            raise ValueError("Unavailable warp file: {0}".format(warp_file))
-        distortion_img = nibabel.load(warp_file)
+        if not os.path.isfile(pixel_shift_map):
+            raise ValueError("Unavailable pixel shift map file: {0}".format(
+                pixel_shift_map))
+        distortion_img = nibabel.load(pixel_shift_map)
         distortion_img_data = distortion_img.get_data()
         distortion_img_data.shape += (1,)
         spacing = distortion_img.header.get_zooms()
@@ -850,7 +833,7 @@ if susceptibility_method == "topup":
 else:
     # For now, except for topup sequences, susceptibility is corrected by
     # applying a voxel shift map generated from either a registration based
-    # method or a an equivalent fieldmap.
+    # method or a rad/sfieldmap.
     # TODO: Apply directly an Hz fieldmap directly into eddy to avoid a double
     # interpolation.
     susceptibility_corrected_dwi = os.path.join(
@@ -935,10 +918,20 @@ if susceptibility_method == "reg":
 
     # t1 has already been registered to dwi by BrainSuite
     shutil.copy(t1_in_dwi_space, t1_to_dwi)
+
+elif susceptibility_method == "topup":
+    flirt(
+        in_file=t1,
+        ref_file=mean_corrected_b0s,
+        dof=6,
+        cost="normmi",
+        out=t1_to_dwi,
+        interp="spline",
+        shfile=inputs["fsl_config"])
 else:
 
-    # For BrainSuite correction, topup correction or no correction, T1 to DWI
-    # transformation matrix has been saved by epi_reg
+    # For B0maps correction or no correction, T1 to DWI transformation matrix
+    # has been saved by epi_reg
     flirt(
         in_file=t1,
         ref_file=corrected_nodiff_undistorted,

--- a/pyconnectome/scripts/pyconnectome_get_eddy_data
+++ b/pyconnectome/scripts/pyconnectome_get_eddy_data
@@ -140,8 +140,9 @@ def get_cmd_line_args():
         "-m", "--dicom",
         required=True, metavar="<path>",
         help="A compressed tarball (.tar.gz) or a folder containing the dMRI "
-             "DICOM files. We assume that all images were acquired with the "
-             "same protocol.")
+             "DICOM files or, for SIEMENS or GE only, a json file containing "
+             "dwell and read-out time. We assume that all images were acquired"
+             "with the same protocol.")
     required.add_argument(
         "-d", "--dwi",
         required=True, metavar="<path>", nargs="+", type=is_file,
@@ -161,8 +162,13 @@ def get_cmd_line_args():
 
     # Optional argument
     parser.add_argument(
-        "-M", "--dicom-info", metavar="<path>", type=is_file,
-        help="Image BIDS description file.")
+        "-O", "--topup-b0",
+        type=is_file, metavar="<path>", nargs="+",
+        help="The b0 data acquired in opposite phase enc. direction.")
+    parser.add_argument(
+        "-D", "--topup-b0-dir",
+        metavar="<path>", nargs="+", choices=("i", "i-", "j", "j-"),
+        help="The b0 data enc.directions.")
     parser.add_argument(
         "-R", "--round-readout-time", action="store_true",
         help="Round read out time value to 3 digits after the decimal point.")
@@ -222,6 +228,8 @@ subject_data["bval"] = concat_bvals
 
 # Get sequence information from dicom
 # > Unzip dicom archive
+dcm_info = None
+output_dicom_dir = None
 if os.path.isfile(inputs["dicom"]):
     if inputs["dicom"].endswith(".tar.gz"):
         output_dicom_dir = os.path.join(output_sub_dir, "dicom")
@@ -229,26 +237,30 @@ if os.path.isfile(inputs["dicom"]):
             os.mkdir(output_dicom_dir)
         cmd = ["tar", "-xzf", inputs["dicom"], "-C", output_dicom_dir]
         subprocess.check_call(cmd)
+    elif inputs["dicom"].endswith(".json"):
+        with open(inputs["dicom"], "rt") as open_file:
+            dcm_info = json.load(open_file)
     else:
         raise ValueError("Unexpected file format: '{0}'.".format(
             inputs["dicom"]))
 else:
     output_dicom_dir = inputs["dicom"]
 
-# > Get dicom information
-if inputs["dicom_info"] is None:
+# > Get dicom information if dicom json was not provided
+if dcm_info is None:
     dcm_info = get_dcm_info(
         dicom_dir=output_dicom_dir,
         outdir=output_sub_dir)
-else:
-    with open(inputs["dicom_info"], "rt") as open_file:
-        dcm_info = json.load(open_file)
 
-# Load a dicom file to get complementary dicom information
-dicom_files = glob.glob(os.path.join(output_dicom_dir, "*"))
-if len(dicom_files) == 0:
-    raise ValueError("No files in '{0}'.".format(output_dicom_dir))
-dicom_img = dicom.read_file(dicom_files[0])
+# If dicom dir or dicom tar.gz has been given, load a dicom file to get
+# complementary dicom information (necessary for Philips scanner)
+if output_dicom_dir is not None:
+    dicom_files = glob.glob(os.path.join(output_dicom_dir, "*"))
+    if len(dicom_files) == 0:
+        raise ValueError("No files in '{0}'.".format(output_dicom_dir))
+    dicom_img = dicom.read_file(dicom_files[0])
+else:
+    dicom_img = None
 
 # Get phase encoding direction
 if "PhaseEncodingDirection" in dcm_info.keys():
@@ -269,9 +281,9 @@ subject_data["DwellTime"] = dwell_time
 
 # Get read out time
 readout_time = get_readout_time(
-    dicom_img=dicom_img,
     dcm_info=dcm_info,
-    dwell_time=dwell_time)
+    dwell_time=dwell_time,
+    dicom_img=dicom_img)
 
 if inputs["round_readout_time"]:
     readout_time = round(readout_time, 3)
@@ -282,18 +294,62 @@ subject_data["TotalReadoutTime"] = readout_time
 acqp_file = os.path.join(output_sub_dir, "acqp.txt")
 with open(acqp_file, "wt") as open_file:
     if dcm_info["Manufacturer"].upper() == "SIEMENS":
-        if dcm_info["PhaseEncodingDirection"] == "i":
-            open_file.write("1 0 0 {0}".format(readout_time))
-        elif dcm_info["PhaseEncodingDirection"] == "i-":
-            open_file.write("-1 0 0 {0}".format(readout_time))
-        elif dcm_info["PhaseEncodingDirection"] == "j":
-            open_file.write("0 1 0 {0}".format(readout_time))
-        elif dcm_info["PhaseEncodingDirection"] == "j-":
-            open_file.write("0 -1 0 {0}".format(readout_time))
+        if inputs["topup_b0"] is not None:
+            if len(inputs["topup_b0"]) != len(inputs["topup_b0_dir"]):
+                raise ValueError(
+                    "Please specify properly the topup input data.")
+            data = []
+            affine = None
+            for enc_dir, path in zip(
+                    inputs["topup_b0_dir"], inputs["topup_b0"]):
+                im = nibabel.load(path)
+                if affine is None:
+                    affine = im.affine
+                else:
+                    assert numpy.allclose(affine, im.affine)
+                arr = im.get_data()
+                for cnt, size in enumerate(arr.shape[:3]):
+                    if size % 2 == 1:
+                        print("[warn] reducing TOPUP B0 image size.")
+                        arr = numpy.delete(arr, -1, axis=cnt)
+                if arr.ndim == 3:
+                    arr.shape += (1, )
+                data.append(arr)
+                nvol = arr.shape[-1]
+                if enc_dir == "i":
+                    row = "1 0 0 {0}".format(readout_time)
+                elif enc_dir == "i-":
+                    row = "-1 0 0 {0}".format(readout_time)
+                elif enc_dir == "j":
+                    row = "0 1 0 {0}".format(readout_time)
+                elif enc_dir == "j-":
+                    row = "0 -1 0 {0}".format(readout_time)
+                else:
+                    raise ValueError("Unknown encode phase direction : "
+                                     "{0}...".format(enc_dir))
+                for indx in range(nvol):
+                    open_file.write(row + "\n")
+
+            # Save concatenated opposed phase encode dir images
+            concatenated_b0s_file = os.path.join(
+                output_sub_dir, "concatenated_b0s.nii.gz")
+            concatenated_b0s = numpy.concatenate(data, axis=-1)
+            concatenated_b0s_im = nibabel.Nifti1Image(concatenated_b0s, affine)
+            nibabel.save(concatenated_b0s_im, concatenated_b0s_file)
+            subject_data["concat+_b0_opposed_polarity"] = concatenated_b0s_file
         else:
-            raise ValueError(
-                "Unknown encode phase direction : {0}...".format(
-                    dcm_info["PhaseEncodingDirection"]))
+            if dcm_info["PhaseEncodingDirection"] == "i":
+                open_file.write("1 0 0 {0}".format(readout_time))
+            elif dcm_info["PhaseEncodingDirection"] == "i-":
+                open_file.write("-1 0 0 {0}".format(readout_time))
+            elif dcm_info["PhaseEncodingDirection"] == "j":
+                open_file.write("0 1 0 {0}".format(readout_time))
+            elif dcm_info["PhaseEncodingDirection"] == "j-":
+                open_file.write("0 -1 0 {0}".format(readout_time))
+            else:
+                raise ValueError(
+                    "Unknown encode phase direction : {0}...".format(
+                        dcm_info["PhaseEncodingDirection"]))
     else:
         print("Only phase encoding direction is assured for subject {0},"
               "orientation may be negative or positive.".format(


### PR DESCRIPTION
pyconnectome/utils/preproctools.py:
* added fsl convertwarp tool wrapper
* passed directly concatenated b0s with different phase encode directions and acqp files to topup function
* put dicom_img parameter as optional for get_dwell_time and get_readout_time functions

pyconnectome/scripts/pyconnectome_get_eddy_data:
* added topup case with phase encode opposed directions images for acqp file creation
* deleted dicom info json optional parameter and reunited it with dicom data mandatory input

pyconnectome/scripts/pyconnectome_dmri_preproc:
* corrected structural to epi registration in topup case
* corrected b0map susceptibility correction
* modified topup b0 inputs as a concatenated volume instead of a list of two opposite-phase images